### PR TITLE
feat: migrate extension from Manifest V2 to Manifest V3

### DIFF
--- a/js/ExtensionEnabler.js
+++ b/js/ExtensionEnabler.js
@@ -17,10 +17,10 @@
     /**
      * List of shorthand objects
      */
-    var array = [];
-    var slice = Array.prototype.slice;
-    var root = this;
-    var TPEnabler = root.TPEnabler = {};
+    const array = [];
+    const slice = Array.prototype.slice;
+    const root = this;
+    const TPEnabler = root.TPEnabler = {};
 
     /**
      * A main routine which executes a specified javascript function

--- a/js/Popup.js
+++ b/js/Popup.js
@@ -1,10 +1,9 @@
 (function () {
-    "use strict";
-    var BG = chrome.extension.getBackgroundPage();
-
+    'use strict';
+    
     $(window).ready(function () {
         $('#go_to_triton').click(function () {
-            BG.goToTritron();
+            chrome.runtime.sendMessage({action: 'goToTritron'});
         });
     });
 

--- a/js/service-worker.js
+++ b/js/service-worker.js
@@ -1,0 +1,48 @@
+/**
+ * Service worker for Tritron Extensions Enabler
+ */
+
+/**
+ * Getter function for the triton web page address.
+ *
+ * @returns {string} the URL to the triton web page.
+ */
+function getTritonUrl() {
+  'use strict';
+  return 'http://triton.ironhelmet.com/';
+}
+
+/**
+ * Opens a specified triton web page inside a
+ * new tab. A new tab will only be created when necessary.
+ *
+ * @param {string} path The path to to be opened triton web page
+ */
+function goToTritron(path) {
+  'use strict';
+  path = path || '';
+  chrome.tabs.query({'url': getTritonUrl() + '*'}, function(tabs) {
+    for (const tab of tabs) {
+      chrome.tabs.update(tab.id, {active: true});
+    }
+    if (tabs.length > 0) return;
+    chrome.tabs.create({
+      url: getTritonUrl() + path,
+      active: true
+    });
+  });
+}
+
+// Listen for clicks on the extension icon
+chrome.action.onClicked.addListener(function callback() {
+  goToTritron();
+});
+
+// Listen for runtime messages from popup
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.action === 'goToTritron') {
+    goToTritron();
+  }
+  // Always return true for async response
+  return true;
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,18 +1,21 @@
 {
-	"manifest_version": 2,
+	"manifest_version": 3,
 	"name" : "Tritron Extensions Enabler",
 	"description": "Provide you some extra features for this awesome game.",
 	"version": "1.0",
 
 	"permissions": [
+		"tabs",
+		"scripting"
+	],
+
+	"host_permissions": [
 		"*://triton.ironhelmet.com/*",
-        "*://www.dropbox.com/*",
-		"tabs"
+        "*://www.dropbox.com/*"
 	],
 
 	"background": {
-		"page" : "background.html",
-		"persistent" : false
+		"service_worker" : "js/service-worker.js"
 	},	
 
 	"content_scripts": [
@@ -26,9 +29,21 @@
 		}
 	],
 
-	"browser_action" : {
+	"action" : {
 		"default_icon": "images/icon.png",
 		"default_popup": "popup.html"
+	},
+	
+	"web_accessible_resources": [
+		{
+			"resources": ["js/lib/jquery-2.1.1.min.js"],
+			"matches": ["*://triton.ironhelmet.com/*"]
+		}
+	],
+	
+	"content_security_policy": {
+		"extension_pages": "script-src 'self'; object-src 'self'",
+		"sandbox": "sandbox allow-scripts allow-forms allow-popups allow-modals; script-src 'self'; object-src 'self'"
 	}
 
 }


### PR DESCRIPTION
## Description

This PR migrates the extension from Manifest V2 to Manifest V3, following Chrome's extension platform updates.

### Changes
- Updated manifest.json to version 3
- Replaced background page with service worker
- Updated popup.js to use message passing instead of direct background page access
- Added proper content security policy
- Made JavaScript more modern with const/let
- Reorganized permissions to use host_permissions
- Added web_accessible_resources with proper scoping
- Removed leftover Manifest V2 files (background.html and Background.js)

### Why
- Manifest V2 support is being phased out by Chrome
- Manifest V3 offers better security and performance
- This ensures the extension will continue to work in future Chrome versions