### PR TITLE
feat: update game URL to np4.ironhelmet.com

### DIFF
--- a/js/ExtensionEnabler.js
+++ b/js/ExtensionEnabler.js
@@ -1,9 +1,9 @@
 /**
- * Extension Enabler for the Game Triton Neptunes Prime 2.
+ * Extension Enabler for the Game Neptune's Pride 4.
  *
  * This file is a simple content script for a google chrome extension
- * which is is responsible to execute Triton extensions
- * inside the execution context of the game page http://triton.ironhelmet.com/game/...
+ * which is is responsible to execute Neptune's Pride extensions
+ * inside the execution context of the game page https://np4.ironhelmet.com/game/...
  *
  * The following extensions are already implemented:
  *

--- a/js/service-worker.js
+++ b/js/service-worker.js
@@ -3,13 +3,13 @@
  */
 
 /**
- * Getter function for the triton web page address.
+ * Getter function for the Neptune's Pride web page address.
  *
- * @returns {string} the URL to the triton web page.
+ * @returns {string} the URL to the Neptune's Pride web page.
  */
 function getTritonUrl() {
   'use strict';
-  return 'http://triton.ironhelmet.com/';
+  return 'https://np4.ironhelmet.com/';
 }
 
 /**

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
-	"name" : "Tritron Extensions Enabler",
-	"description": "Provide you some extra features for this awesome game.",
+	"name" : "Neptune's Pride Extensions Enabler",
+	"description": "Provides extra features for Neptune's Pride 4.",
 	"version": "1.0",
 
 	"permissions": [
@@ -10,7 +10,7 @@
 	],
 
 	"host_permissions": [
-		"*://triton.ironhelmet.com/*",
+		"*://np4.ironhelmet.com/*",
         "*://www.dropbox.com/*"
 	],
 
@@ -21,7 +21,7 @@
 	"content_scripts": [
 		{ 
 			"matches": [
-				"*://triton.ironhelmet.com/game/*"
+				"*://np4.ironhelmet.com/game/*"
 			], 
 			"js": [ "js/lib/jquery-2.1.1.min.js", "js/ExtensionEnabler.js" ],
 			"run_at" : "document_end",
@@ -37,7 +37,7 @@
 	"web_accessible_resources": [
 		{
 			"resources": ["js/lib/jquery-2.1.1.min.js"],
-			"matches": ["*://triton.ironhelmet.com/*"]
+			"matches": ["*://np4.ironhelmet.com/*"]
 		}
 	],
 	


### PR DESCRIPTION
## Description

This PR updates all references to the game URL from the old http://triton.ironhelmet.com to the new https://np4.ironhelmet.com domain.

### Changes
- Updated URLs in service-worker.js
- Updated URLs in manifest.json (host_permissions, content_scripts matches, web_accessible_resources)
- Updated extension name and description to reference Neptune's Pride 4
- Updated comment in ExtensionEnabler.js to reference the correct game URL

### Why
- The game has moved from triton.ironhelmet.com to np4.ironhelmet.com
- The extension needs to target the new URL to function properly
- Updated to use HTTPS for better security